### PR TITLE
Update Dependabot configuration to include labels on the GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: "weekly"
     commit-message:
-      prefix: "Chore: "
+      prefix: 'chore: '
     labels:
       - github_actions
       - dependabot


### PR DESCRIPTION
This PR updates the Dependabot configuration to include labels on the GitHub Actions.
This work uses yq defaults to create the output in a standardised way.

Links to intenthq/infrastructure#6834